### PR TITLE
Support for v4+ XMS multiple clusters and README udpates

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Options
     --v                     Specify to signify the object to snap is a volume.
 
     --snap=<object_to_snap> Object to snap, either a volume or folder
+    
+    --cluster=<clustername> Optional name of XtremIO cluster (primarily for multiple
+                            clusters attached to same XMS)
 
     --n=<number_of_snaps>   Number of snapshots to retain [default: 5]
 
@@ -68,7 +71,8 @@ Options
 
     --tf=<target_folder>    When specified, a _Snapshot subfolder will be created
                             in this folder.  If not used, snapshots will be saved
-                            in a _Snapshot folder at the root.
+                            in a _Snapshot folder at the root.  For XtremIO 4+, 
+                            this is the TAG that will be placed on the snapshot
 
     --l=<log_path>          [default: """+var_cwd+"""/XtremIOSnap.log]
 
@@ -124,7 +128,7 @@ Showing the snapshot hierarchy view with a mix of individual volume snaps and fo
 
 Contributing
 -----------
-Please contribute in any way to the project.  Specifically, normalizing differnet image sizes, locations, and intance types would be easy adds to enhance the usefulness of the project.
+Please contribute in any way to the project.  Specifically, normalizing differnet image sizes, locations, and instance types would be easy adds to enhance the usefulness of the project.
 
 
 Licensing

--- a/XtremIOSnap.py
+++ b/XtremIOSnap.py
@@ -35,13 +35,13 @@ var_cwd =  os.getcwd()
 __doc__ = """
 XtremIOSnap
 
-Version 3.0
+Version 3.2
 
 Usage:
     XtremIOSnap -h | --help
     XtremIOSnap (--encode) XMS_USER XMS_PASS [--l=<log_path>] [--debug]
-    XtremIOSnap XMS_IP XMS_USER XMS_PASS [--e]  [(--f --snap=<object_to_snap>)] [--n=<number_of_snaps>] [--schedule=<schedule>] [--tf=<target_folder>] [--l=<log_path>] [--debug]
-    XtremIOSnap XMS_IP XMS_USER XMS_PASS [--e]  [(--v --snap=<object_to_snap>)] [--n=<number_of_snaps>] [--schedule=<schedule>] [--tf=<target_folder>] [--l=<log_path>] [--debug]
+    XtremIOSnap XMS_IP XMS_USER XMS_PASS [--e]  [(--f --snap=<object_to_snap>)] [--n=<number_of_snaps>] [--schedule=<schedule>] [--tf=<target_folder>] [--l=<log_path>] [--debug] [--cluster=<cluster>]
+    XtremIOSnap XMS_IP XMS_USER XMS_PASS [--e]  [(--v --snap=<object_to_snap>)] [--n=<number_of_snaps>] [--schedule=<schedule>] [--tf=<target_folder>] [--l=<log_path>] [--debug] [--cluster=<cluster>]
 
 Create and maintain snapshots of both volumes and folders on an XtremIO array
 utilizing the REST API interface.  Designed and tested for XtremIO v3.0+.
@@ -67,6 +67,9 @@ Options:
     --v                     Specify to signify the object to snap is a volume.
 
     --snap=<object_to_snap> Object to snap, either a volume or folder
+
+    --cluster=<clustername> (Optional) Name of cluster on XMS where volumes are 
+                            to be snapped
 
     --n=<number_of_snaps>   Number of snapshots to retain [default: 5]
 
@@ -113,6 +116,7 @@ def main():
     parent_folder_id = main_options.var_snap_tgt_folder
     num_snaps = options['--n']
     snap_src = options['--snap']
+    clus_name = options['--cluster']
     SnapFolder = '_Snapshots'
     bool_create_folder = True ## will change to False if the /_Snapshots folder already exists
     rest = Restful(
@@ -120,7 +124,8 @@ def main():
         options['--debug'],
         XMS_IP,
         XMS_USER,
-        XMS_PASS
+        XMS_PASS,
+        clus_name
         )
     folder_list = rest._get(
         '/api/json/types/volume-folders'


### PR DESCRIPTION
This PR adds a parameter for passing in the name of the cluster, for XMS's where there are more than 1 cluster connected, this is a required argument.   

Also updated the README to reflect this change.    

You will want to rebuild the .exe with these changes.
